### PR TITLE
feat(consistent-type-specifier-style)!: rename options

### DIFF
--- a/src/rules/consistent-type-specifier-style/README.md
+++ b/src/rules/consistent-type-specifier-style/README.md
@@ -4,4 +4,7 @@ Origin docs: https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/ru
 
 ## Changes
 
+- Resolve https://github.com/un-ts/eslint-plugin-import-x/issues/221.
+  - Rename `prefer-top-level` to `top-level`, `prefer-inline` to `inline`.
+  - Add new option `prefer-top-level`, allow `import { Foo, type Bar } from 'Foo'`, don't allow `import { type Foo } from 'Foo'`. More detail see .
 - Drop flow support.

--- a/src/rules/consistent-type-specifier-style/README.md
+++ b/src/rules/consistent-type-specifier-style/README.md
@@ -6,5 +6,7 @@ Origin docs: https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/ru
 
 - Resolve https://github.com/un-ts/eslint-plugin-import-x/issues/221.
   - Rename `prefer-top-level` to `top-level`, `prefer-inline` to `inline`.
-  - Add new option `prefer-top-level`, allow `import { Foo, type Bar } from 'Foo'`, don't allow `import { type Foo } from 'Foo'`. More detail see .
+  - Add new option `prefer-top-level`.
+    - Allow `import { Foo, type Bar } from 'Foo'`.
+    - Don't allow `import { type Foo } from 'Foo'`.
 - Drop flow support.

--- a/src/rules/consistent-type-specifier-style/consistent-type-specifier-style.test.ts
+++ b/src/rules/consistent-type-specifier-style/consistent-type-specifier-style.test.ts
@@ -8,115 +8,115 @@ run<Options, MessageId>({
   rule,
   valid: [
     //
-    // prefer-top-level
+    // top-level
     //
     {
       code: 'import Foo from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
     },
     {
       code: 'import type Foo from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
     },
     {
       code: 'import { Foo } from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
     },
     {
       code: 'import { Foo as Bar } from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
     },
     {
       code: 'import * as Foo from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
     },
     {
       code: 'import \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
     },
     {
       code: 'import {} from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
     },
     {
       code: 'import type {} from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
     },
     {
       code: 'import type { Foo } from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
     },
     {
       code: 'import type { Foo as Bar } from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
     },
     {
       code: 'import type { Foo, Bar, Baz, Bam } from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
     },
 
     //
-    // prefer-inline
+    // inline
     //
     {
       code: 'import Foo from \'Foo\';',
-      options: ['prefer-inline'],
+      options: ['inline'],
     },
     {
       code: 'import type Foo from \'Foo\';',
-      options: ['prefer-inline'],
+      options: ['inline'],
     },
     {
       code: 'import { Foo } from \'Foo\';',
-      options: ['prefer-inline'],
+      options: ['inline'],
     },
     {
       code: 'import { Foo as Bar } from \'Foo\';',
-      options: ['prefer-inline'],
+      options: ['inline'],
     },
     {
       code: 'import * as Foo from \'Foo\';',
-      options: ['prefer-inline'],
+      options: ['inline'],
     },
     {
       code: 'import \'Foo\';',
-      options: ['prefer-inline'],
+      options: ['inline'],
     },
     {
       code: 'import {} from \'Foo\';',
-      options: ['prefer-inline'],
+      options: ['inline'],
     },
     {
       code: 'import type {} from \'Foo\';',
-      options: ['prefer-inline'],
+      options: ['inline'],
     },
     {
       code: 'import { type Foo } from \'Foo\';',
-      options: ['prefer-inline'],
+      options: ['inline'],
     },
     {
       code: 'import { type Foo as Bar } from \'Foo\';',
-      options: ['prefer-inline'],
+      options: ['inline'],
     },
     {
       code: 'import { type Foo, type Bar, Baz, Bam } from \'Foo\';',
-      options: ['prefer-inline'],
+      options: ['inline'],
     },
 
     //
     // always valid
     //
-    { code: `import type * as Foo from 'Foo';` },
+    { code: 'import type * as Foo from \'Foo\';' },
   ],
   invalid: [
 
     //
-    // prefer-top-level
+    // top-level
     //
     {
       code: 'import { type Foo } from \'Foo\';',
       output: 'import type {Foo} from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
       errors: [
         {
           messageId: 'topLevel',
@@ -130,7 +130,7 @@ run<Options, MessageId>({
     {
       code: 'import { type Foo as Bar } from \'Foo\';',
       output: 'import type {Foo as Bar} from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
       errors: [
         { messageId: 'topLevel', type: AST_NODE_TYPES.ImportDeclaration },
       ],
@@ -138,7 +138,7 @@ run<Options, MessageId>({
     {
       code: 'import { type Foo, type Bar } from \'Foo\';',
       output: 'import type {Foo, Bar} from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
       errors: [
         { messageId: 'topLevel', type: AST_NODE_TYPES.ImportDeclaration },
       ],
@@ -146,25 +146,25 @@ run<Options, MessageId>({
     {
       code: 'import { Foo, type Bar } from \'Foo\';',
       output: 'import { Foo  } from \'Foo\';\nimport type {Bar} from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
       errors: [{ messageId: 'topLevel', type: AST_NODE_TYPES.ImportSpecifier }],
     },
     {
       code: 'import { type Foo, Bar } from \'Foo\';',
       output: 'import {  Bar } from \'Foo\';\nimport type {Foo} from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
       errors: [{ messageId: 'topLevel', type: AST_NODE_TYPES.ImportSpecifier }],
     },
     {
       code: 'import Foo, { type Bar } from \'Foo\';',
       output: 'import Foo from \'Foo\';\nimport type {Bar} from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
       errors: [{ messageId: 'topLevel', type: AST_NODE_TYPES.ImportSpecifier }],
     },
     {
       code: 'import Foo, { type Bar, Baz } from \'Foo\';',
       output: 'import Foo, {  Baz } from \'Foo\';\nimport type {Bar} from \'Foo\';',
-      options: ['prefer-top-level'],
+      options: ['top-level'],
       errors: [{ messageId: 'topLevel', type: AST_NODE_TYPES.ImportSpecifier }],
     },
     // https://github.com/import-js/eslint-plugin-import-x/issues/2753
@@ -192,17 +192,17 @@ run<Options, MessageId>({
           Component5,
         } from "package-2";
       `,
-      options: ['prefer-top-level'],
+      options: ['top-level'],
       errors: [{ messageId: 'topLevel', type: AST_NODE_TYPES.ImportSpecifier }],
     },
 
     //
-    // prefer-inline
+    // inline
     //
     {
       code: 'import type { Foo } from \'Foo\';',
       output: 'import  { type Foo } from \'Foo\';',
-      options: ['prefer-inline'],
+      options: ['inline'],
       errors: [
         {
           messageId: 'inline',
@@ -216,7 +216,7 @@ run<Options, MessageId>({
     {
       code: 'import type { Foo, Bar, Baz } from \'Foo\';',
       output: 'import  { type Foo, type Bar, type Baz } from \'Foo\';',
-      options: ['prefer-inline'],
+      options: ['inline'],
       errors: [{ messageId: 'inline', type: AST_NODE_TYPES.ImportDeclaration }],
     },
   ],

--- a/src/rules/consistent-type-specifier-style/consistent-type-specifier-style.test.ts
+++ b/src/rules/consistent-type-specifier-style/consistent-type-specifier-style.test.ts
@@ -55,6 +55,16 @@ run<Options, MessageId>({
       options: ['top-level'],
     },
 
+    // prefer-top-level
+    {
+      code: `import type { Foo } from 'Foo'`,
+      options: ['prefer-top-level'],
+    },
+    {
+      code: `import { Foo, type Bar } from 'Foo'`,
+      options: ['prefer-top-level'],
+    },
+
     //
     // inline
     //
@@ -194,6 +204,14 @@ run<Options, MessageId>({
       `,
       options: ['top-level'],
       errors: [{ messageId: 'topLevel', type: AST_NODE_TYPES.ImportSpecifier }],
+    },
+
+    // prefer-top-level
+    {
+      code: `import { type Foo, type Bar } from 'Foo';`,
+      output: `import type {Foo, Bar} from 'Foo';`,
+      options: ['prefer-top-level'],
+      errors: [{ messageId: 'topLevel', type: AST_NODE_TYPES.ImportDeclaration }],
     },
 
     //

--- a/src/rules/consistent-type-specifier-style/consistent-type-specifier-style.ts
+++ b/src/rules/consistent-type-specifier-style/consistent-type-specifier-style.ts
@@ -23,7 +23,7 @@ function getImportText(
   return `import type {${names.join(', ')}} from ${sourceString};`
 }
 
-export type Options = ['prefer-inline' | 'prefer-top-level']
+export type Options = ['inline' | 'top-level']
 
 export type MessageId = 'inline' | 'topLevel'
 
@@ -38,8 +38,8 @@ export default createRule<Options, MessageId>({
     schema: [
       {
         type: 'string',
-        enum: ['prefer-top-level', 'prefer-inline'],
-        default: 'prefer-top-level',
+        enum: ['top-level', 'inline'],
+        default: 'top-level',
       },
     ],
     messages: {
@@ -47,11 +47,11 @@ export default createRule<Options, MessageId>({
       topLevel: 'Prefer using a top-level {{kind}}-only import instead of inline {{kind}} specifiers.',
     },
   },
-  defaultOptions: ['prefer-top-level'],
+  defaultOptions: ['top-level'],
   create(context) {
     const { sourceCode } = context
 
-    if (context.options[0] === 'prefer-inline') {
+    if (context.options[0] === 'inline') {
       return {
         ImportDeclaration(node) {
           if (node.importKind === 'value' || node.importKind == null) {
@@ -92,7 +92,7 @@ export default createRule<Options, MessageId>({
       }
     }
 
-    // prefer-top-level
+    // top-level
     return {
       ImportDeclaration(node) {
         if (

--- a/src/rules/consistent-type-specifier-style/consistent-type-specifier-style.ts
+++ b/src/rules/consistent-type-specifier-style/consistent-type-specifier-style.ts
@@ -23,7 +23,7 @@ function getImportText(
   return `import type {${names.join(', ')}} from ${sourceString};`
 }
 
-export type Options = ['inline' | 'top-level']
+export type Options = ['inline' | 'top-level' | 'prefer-top-level']
 
 export type MessageId = 'inline' | 'topLevel'
 
@@ -38,7 +38,7 @@ export default createRule<Options, MessageId>({
     schema: [
       {
         type: 'string',
-        enum: ['top-level', 'inline'],
+        enum: ['top-level', 'inline', 'prefer-top-level'],
         default: 'top-level',
       },
     ],
@@ -48,10 +48,10 @@ export default createRule<Options, MessageId>({
     },
   },
   defaultOptions: ['top-level'],
-  create(context) {
+  create(context, [options]) {
     const { sourceCode } = context
 
-    if (context.options[0] === 'inline') {
+    if (options === 'inline') {
       return {
         ImportDeclaration(node) {
           if (node.importKind === 'value' || node.importKind == null) {
@@ -151,7 +151,7 @@ export default createRule<Options, MessageId>({
               return fixer.replaceText(node, typeImport)
             },
           })
-        } else {
+        } else if (options === 'top-level') {
           // remove specific specifiers and insert new imports for them
           for (const specifier of typeSpecifiers) {
             context.report({


### PR DESCRIPTION
This change follows https://github.com/un-ts/eslint-plugin-import-x/issues/221.

- Rename `prefer-top-level` to `top-level`, `prefer-inline` to `inline`.
- Add new option `prefer-top-level`.
	- Allow `import { Foo, type Bar } from 'Foo'`
	- Don't allow `import { type Foo } from 'Foo'`.